### PR TITLE
github actionsのワークフローの依存アクションのバージョンを最新化

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -9,6 +9,7 @@ name: Deploy static content to GitHub Pages
 on:
   push:
     branches: ["master"]
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -30,16 +31,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
         # 各デモページにアクセスキーを設定する（デモページの各htmlファイルには、アクセスキーを直接書かないようにしている）
       - name: Set EWS access key
         run: sed -i 's/YOUR_ACCESS_KEY/${{secrets.EWS_ACCESS_KEY}}/g' ./sample/*.html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
-          path: '.'
+          path: "."
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
参考：2025年1月30日以降、actions/upload-artifact@v3が使用不可となっている。 https://github.com/orgs/community/discussions/142581